### PR TITLE
Fix duplicate symbols when compile library with libTiff.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,6 @@ endif(MSVC)
 set(LIBHPDF_NAME ${LIBHPDF_NAME}hpdf)
 set(LIBHPDF_NAME_STATIC ${LIBHPDF_NAME}s)
 
-if (APPLE)
-  set(LIBHPDF_SHARED NO)
-endif()
-
 
 # =======================================================================
 # command line options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ endif(MSVC)
 set(LIBHPDF_NAME ${LIBHPDF_NAME}hpdf)
 set(LIBHPDF_NAME_STATIC ${LIBHPDF_NAME}s)
 
+if (APPLE)
+  set(LIBHPDF_SHARED NO)
+endif()
+
+
 # =======================================================================
 # command line options
 # =======================================================================
@@ -52,6 +57,10 @@ option(LIBHPDF_SHARED "Build shared lib" YES)
 option(LIBHPDF_STATIC "Build static lib" YES)
 option(LIBHPDF_EXAMPLES "Build libharu examples" NO)
 option(DEVPAK "Create DevPackage" NO)
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
+endif()
 
 # Enable exceptions on linux if required
 # (eg if you are using libharu in a C++ environment,

--- a/src/hpdf_image_ccitt.c
+++ b/src/hpdf_image_ccitt.c
@@ -21,7 +21,6 @@
 #include <memory.h>
 #include <assert.h>
 
-#define	G3CODES
 #include "t4.h"
 
 typedef unsigned int uint32;

--- a/src/hpdf_image_png.c
+++ b/src/hpdf_image_png.c
@@ -20,7 +20,7 @@
 #include "hpdf_image.h"
 
 #ifndef LIBHPDF_HAVE_NOPNGLIB
-#include <png.h>
+#include "png.h"
 #include <string.h>
 
 static void


### PR DESCRIPTION
Apparently library and lib tiff use the same 't4.h' file.
