### PR TITLE
bugfix: overflow in FtoA

### DIFF
--- a/src/hpdf_utils.c
+++ b/src/hpdf_utils.c
@@ -209,7 +209,7 @@ HPDF_FToA  (char       *s,
     }
 
     /* Compute the decimal precision to write at least 5 significant figures */
-    logVal = (HPDF_INT32)(val > 1e-20 ? log10(val) : 0.);
+    logVal = (HPDF_INT32)(val > 1e-13 ? log10(val) : 0.);
     if (logVal >= 0) {
         prec = 5;
     }
@@ -459,4 +459,3 @@ HPDF_UInt16Swap  (HPDF_UINT16  *value)
     HPDF_MemCpy (u, (HPDF_BYTE*)value, 2);
     *value = (HPDF_UINT16)((HPDF_UINT16)u[0] << 8 | (HPDF_UINT16)u[1]);
 }
-


### PR DESCRIPTION
if the constant is set to $10^{-20}$ `logVal` can take the value $-19$ leading to $prec = 24$. Later we set `fShift` to $10^\text{prec}$ which is too large for a 64bit int. Setting the initial constant to $13$ guarantees that `fShift` is set to a maximum of $10^{18}$ which is just within the 64bit int range.